### PR TITLE
update for changed input schema

### DIFF
--- a/nefino_geosync/compose_requests.py
+++ b/nefino_geosync/compose_requests.py
@@ -65,4 +65,4 @@ def compose_single_request(state: str,
                                   scope=scope, 
                                   requests=requests, 
                                   operations=DUMMY_OPERATIONS)
-    return GeoAnalysisInput(name=f'sync_{state}', specs=[spec])
+    return GeoAnalysisInput(name=f'sync_{state}', specs=spec)

--- a/nefino_geosync/schema.json
+++ b/nefino_geosync/schema.json
@@ -823,17 +823,9 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "GeoAnalysisObjectInput",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "INPUT_OBJECT",
+                  "name": "GeoAnalysisObjectInput",
+                  "ofType": null
                 }
               }
             }

--- a/nefino_geosync/schema.py
+++ b/nefino_geosync/schema.py
@@ -75,7 +75,7 @@ class GeoAnalysisInput(sgqlc.types.Input):
     __schema__ = schema
     __field_names__ = ('name', 'specs')
     name = sgqlc.types.Field(String, graphql_name='name')
-    specs = sgqlc.types.Field(sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null('GeoAnalysisObjectInput'))), graphql_name='specs')
+    specs = sgqlc.types.Field(sgqlc.types.non_null('GeoAnalysisObjectInput'), graphql_name='specs')
 
 
 class GeoAnalysisLayerInput(sgqlc.types.Input):


### PR DESCRIPTION
Quick summary: update types and take specs out of list when composing queries.

We are changing the type of `specs` from a list to a single item in both input types and query types which we don't use in the sync app.
The backend system never had the ability to process multiple specs in one request, and the flexibility of graphql means it's not necessary.

Internal note: part of https://github.com/nefino/nefino_li/issues/5411