### PR TITLE
fix: Add missing git checkout

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Checkout repository 📦
+        uses: actions/checkout@v4
       - name: Check for labels 📚
         id: check-labels
         run: |


### PR DESCRIPTION
The PR label check workflow fails as the git checkout step is missing.