### PR TITLE
Improve handling of unsynced analyses

### DIFF
--- a/nefino_geosync/download_analysis.py
+++ b/nefino_geosync/download_analysis.py
@@ -85,7 +85,21 @@ def unpack_items(zip_root: str, pk: str, started_at: datetime) -> None:
 
     # Update the journal to mark layers as updated. We might have empty layers so we do set all requested layers as
     # updated.
-    layers_to_mark_updated = journal.analysis_requested_layers[pk]
+    if pk in journal.analysis_requested_layers:
+        layers_to_mark_updated = journal.analysis_requested_layers[pk]
+    else:
+        # Fallback: extract layer names from the ZIP file structure as a safety net
+        print(f'⚠️  Warning: No recorded requested layers for analysis {pk}. Extracting from ZIP structure.')
+        layers_to_mark_updated = set()
+        for cluster in (
+            f for f in os.listdir(base_path) if f != 'analysis_area' and os.path.isdir(os.path.join(base_path, f))
+        ):
+            cluster_dir = os.path.join(base_path, cluster)
+            for file in os.listdir(cluster_dir):
+                match = re.match(FILE_NAME_PATTERN, file)
+                if match:
+                    layers_to_mark_updated.add(match.group('layer'))
+
     print(f'Recording {len(layers_to_mark_updated)} requested layers as updated for state {state}')
 
     journal.record_layers_unpacked(layers_to_mark_updated, state, started_at)

--- a/nefino_geosync/download_completed_analyses.py
+++ b/nefino_geosync/download_completed_analyses.py
@@ -12,6 +12,9 @@ def download_completed_analyses(client: HTTPEndpoint) -> None:
     for analysis in get_downloadable_analyses(client):
         if analysis.pk not in journal.synced_analyses:
             if analysis.pk in journal.analysis_states:
+                if analysis.pk not in journal.analysis_requested_layers:
+                    print(f'⚠️  Warning: Analysis {analysis.pk} found but has no recorded requested layers. Skipping.')
+                    continue
                 download_analysis(analysis)
                 print(f'Downloaded analysis {analysis.pk}')
         elif args.verbose:

--- a/nefino_geosync/journal.py
+++ b/nefino_geosync/journal.py
@@ -38,6 +38,7 @@ class Journal:
         self.last_geosync_run: datetime = None
 
         self.load_analysis_states()
+        self.load_analysis_requested_layers()
         self.load_layer_last_updates()
         self.load_synced_analyses()
         self.load_last_geosync_run()
@@ -55,6 +56,24 @@ class Journal:
         except FileNotFoundError:
             # we already have an empty dictionary as the field value
             print('No saved analysis states found.')
+
+    def save_analysis_requested_layers(self) -> None:
+        """Saves the analysis requested layers to a file."""
+        # Convert sets to lists for JSON serialization
+        serializable_data = {pk: list(layers) for pk, layers in self.analysis_requested_layers.items()}
+        with open(os.path.join(get_app_directory(), 'analysis_requested_layers.json'), 'w') as f:
+            json.dump(serializable_data, f)
+
+    def load_analysis_requested_layers(self) -> None:
+        """Loads the analysis requested layers from a file."""
+        try:
+            with open(os.path.join(get_app_directory(), 'analysis_requested_layers.json'), 'r') as f:
+                data = json.load(f)
+                # Convert lists back to sets
+                self.analysis_requested_layers = {pk: set(layers) for pk, layers in data.items()}
+        except FileNotFoundError:
+            # we already have an empty dictionary as the field value
+            print('No saved analysis requested layers found.')
 
     def save_layer_last_updates(self) -> None:
         """Saves the layer last updates to a file."""
@@ -124,6 +143,7 @@ class Journal:
                     requested_layers.add(layer.layer_name)
             self.analysis_requested_layers[analysis_metadata.pk] = requested_layers
         self.save_analysis_states()
+        self.save_analysis_requested_layers()
 
     def record_layers_unpacked(self, layers: Set[str], state: str, started_at: datetime) -> None:
         """Records the layers that have been unpacked, and when they were last updated."""
@@ -164,3 +184,7 @@ class Journal:
         """Records that the analysis has been downloaded and unpacked."""
         self.synced_analyses.add(pk)
         self.save_synced_analyses()
+        # Clean up the requested layers for this analysis to prevent unbounded growth
+        if pk in self.analysis_requested_layers:
+            del self.analysis_requested_layers[pk]
+            self.save_analysis_requested_layers()

--- a/nefino_geosync/journal.py
+++ b/nefino_geosync/journal.py
@@ -145,6 +145,15 @@ class Journal:
         self.save_analysis_states()
         self.save_analysis_requested_layers()
 
+    def clear_analysis_requested_layers(self) -> None:
+        """Clears all analysis requested layers at the start of a new run."""
+        if self.analysis_requested_layers:
+            print(
+                f"Clearing {len(self.analysis_requested_layers)} old analysis metadata entries from previous runs"
+            )
+            self.analysis_requested_layers.clear()
+            self.save_analysis_requested_layers()
+
     def record_layers_unpacked(self, layers: Set[str], state: str, started_at: datetime) -> None:
         """Records the layers that have been unpacked, and when they were last updated."""
         print(f'Recording layers {layers} as unpacked for state {state}')

--- a/nefino_geosync/start_analyses.py
+++ b/nefino_geosync/start_analyses.py
@@ -32,7 +32,8 @@ def start_analyses(client: HTTPEndpoint, changelog_result: LayerChangelogResult 
     local_data = client(local_op)
     check_errors(local_data, 'Failed to fetch regional layer availability')
     local_availability = local_op + local_data
-
+    # Clear previous analysis requested layers
+    journal.clear_analysis_requested_layers()
     # Start the analyses
     analysis_inputs = compose_complete_requests(general_availability, local_availability, changelog_result)
     if len(analysis_inputs) == 0:


### PR DESCRIPTION
This PR fixes problems that occurr when analyses are not registered as synced. It saves the requested layers in a json file such that they can be retrieved in a new session when running with resume-flag.